### PR TITLE
Add link to  Wikipedia2Vec

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Links for pre-trained word vectors:
 * [Huang et al. (2012)'s embeddings (HSMN+csmRNN)](http://stanford.edu/~lmthang/morphoNLM/)
 * [Collobert et al. (2011)'s embeddings (CW+csmRNN)](http://stanford.edu/~lmthang/morphoNLM/)
 * [BPEmb: subword embeddings for 275 languages](https://github.com/bheinzerling/bpemb)
+* [Wikipedia2Vec: pretrained word and entity embeddings for 12 languages](https://wikipedia2vec.github.io/wikipedia2vec/pretrained/)
 
 <!--
 ## Articles


### PR DESCRIPTION
Adds a link to https://wikipedia2vec.github.io/wikipedia2vec/pretrained/.
This page provides embedding models trained on Wikipedia for 12 languages.